### PR TITLE
recon-jet running android 4.1.2 exception fix -- set a lower frame rate

### DIFF
--- a/src/android/CameraManager.java
+++ b/src/android/CameraManager.java
@@ -17,6 +17,7 @@ import android.graphics.SurfaceTexture;
 import android.hardware.Camera;
 import android.hardware.Camera.Parameters;
 import android.hardware.Camera.Size;
+import android.media.CamcorderProfile;
 import android.os.Build;
 import android.os.Handler;
 import android.util.Log;
@@ -32,6 +33,8 @@ public final class CameraManager {
 	private final Context context;
 	public final CameraConfigurationManager configManager;
 	public Camera camera;
+	Camera.Parameters param;
+	CamcorderProfile camcorderProfile;
 	private boolean initialized;
 	public boolean previewing;
 
@@ -108,6 +111,14 @@ public final class CameraManager {
 			}
 			
 			if (DEBUG) Log.i(TAG, "Camera open success");
+
+			// Get the camera profile. Low quality is adequate for display our demo purposes right now.
+			camcorderProfile = CamcorderProfile.get(CamcorderProfile.QUALITY_LOW);
+
+			param = camera.getParameters();
+			param.setPreviewFrameRate(camcorderProfile.videoFrameRate);
+			camera.setParameters(param);
+
 						
 			camera.setPreviewDisplay(null);
 			
@@ -125,11 +136,11 @@ public final class CameraManager {
 
 			if (!initialized) {
 				initialized = true;
-				configManager.initFromCameraParameters(camera);
-				if (DEBUG) Log.i(TAG, "configManager initialized");
+				//configManager.initFromCameraParameters(camera);
+				//if (DEBUG) Log.i(TAG, "configManager initialized");
 			}
-			configManager.setDesiredCameraParameters(camera);
-			if (DEBUG) Log.i(TAG, "Camera set desired parameters");
+			//configManager.setDesiredCameraParameters(camera);
+			//if (DEBUG) Log.i(TAG, "Camera set desired parameters");
 					
 
 		} else {
@@ -642,6 +653,7 @@ final class PreviewCallback implements Camera.PreviewCallback {
 	public static float currentFPS = 0f;
 
 	private final CameraConfigurationManager configManager;
+	Camera.Parameters param;
 
 	public byte[][] frameBuffers;
 	public int fbCounter = 0;
@@ -724,8 +736,9 @@ final class PreviewCallback implements Camera.PreviewCallback {
 
 		try
 		{
-			int w = this.configManager.cameraResolution.x;
-			int h = this.configManager.cameraResolution.y;
+			param = camera.getParameters();
+			int w = param.getPreviewSize().width;
+			int h = param.getPreviewSize().height;
 
 			int[] rgbArray = new int[w * h];
 
@@ -749,6 +762,7 @@ final class PreviewCallback implements Camera.PreviewCallback {
 			{
 				bitmap.compress(Bitmap.CompressFormat.JPEG, 75, outputStream);
 			}
+
 
 			synchronized (this)
 			{


### PR DESCRIPTION
Reworked the code to set the framerate to be LOW_QUALITY since that is all the recon can currently handle. The exception in setParameters no longer occurs on the recon-jet

5-19 09:00:13.441 7895-7895/com.example.hello E/PluginManager: Uncaught exception from plugin
                                                                java.lang.RuntimeException: setParameters failed
                                                                    at android.hardware.Camera.native_setParameters(Native Method)
                                                                    at android.hardware.Camera.setParameters(Camera.java:1410)
                                                                    at com.moonware.cameraserver.CameraConfigurationManager.setDesiredCameraParameters(CameraManager.java:526)
                                                                    at com.moonware.cameraserver.CameraManager.openDriver(CameraManager.java:131)
                                                                    at com.moonware.cameraserver.CameraServer.startCapture(CameraServer.java:460)
                                                                    at com.moonware.cameraserver.CameraServer.startCamera(CameraServer.java:317)
                                                                    at com.moonware.cameraserver.CameraServer.execute(CameraServer.java:102)
                                                                    at org.apache.cordova.CordovaPlugin.execute(CordovaPlugin.java:98)
                                                                    at org.apache.cordova.PluginManager.exec(PluginManager.java:133)
                                                                    at org.apache.cordova.CordovaBridge.jsExec(CordovaBridge.java:59)
                                                                    at org.apache.cordova.CordovaBridge.promptOnJsPrompt(CordovaBridge.java:135)
                                                                    at org.apache.cordova.engine.SystemWebChromeClient.onJsPrompt(SystemWebChromeClient.java:124)
                                                                    at android.webkit.CallbackProxy.handleMessage(CallbackProxy.java:655)
                                                                    at android.os.Handler.dispatchMessage(Handler.java:99)
                                                                    at android.os.Looper.loop(Looper.java:137)
                                                                    at android.app.ActivityThread.main(ActivityThread.java:4745)
                                                                    at java.lang.reflect.Method.invokeNative(Native Method)
                                                                    at java.lang.reflect.Method.invoke(Method.java:511)
                                                                    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:786)
                                                                    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:553)
                                                                    at dalvik.system.NativeStart.main(Native Method)
05-19 09:00:13.441 7895-7895/com.example.hello I/Web Console: Failed to start camera capture: setParameters failed at null:27
